### PR TITLE
Removed `cannotBeEmpty()` check from `fpn_tag.model` configuration key

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,6 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('model')
                     ->isRequired()
-                    ->cannotBeEmpty()
                     ->children()
                         ->scalarNode('tag_class')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('tagging_class')->isRequired()->cannotBeEmpty()->end()


### PR DESCRIPTION
# Description
`cannotBeEmpty()` validation check doesn't work with arrayNodes and throws an error with Symfony 3.4(dev).